### PR TITLE
Scope panel visibility styles to left sidebar

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -211,10 +211,13 @@ body.resizing-sidebar * {
 /* Panels */
 .panel {
     padding: 16px;
+}
+
+.left-sidebar .panel {
     display: none;
 }
 
-.panel.active {
+.left-sidebar .panel.active {
     display: block;
 }
 


### PR DESCRIPTION
## Summary
- scope panel display toggles to the left sidebar so right sidebar panels remain visible

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d8557f9210833391d12f0745521c83