### PR TITLE
Preserve math markup when exporting XML

### DIFF
--- a/script.js
+++ b/script.js
@@ -504,9 +504,23 @@ class PreTeXtCanvas {
         // Replace math containers with <me>/<md> elements
         container.querySelectorAll('.math-expression, .math-display').forEach((mathEl) => {
             const isDisplay = mathEl.classList.contains('math-display');
-            const pretext = mathEl.dataset.pretext || stripDelimiters(mathEl.textContent || '', isDisplay ? 'display' : 'inline');
+            const storedPretext = mathEl.dataset.pretext;
             const replacement = document.createElement(isDisplay ? 'md' : 'me');
-            replacement.textContent = pretext;
+
+            if (storedPretext && storedPretext.trim()) {
+                const temp = document.createElement('div');
+                temp.innerHTML = storedPretext;
+                while (temp.firstChild) {
+                    replacement.appendChild(temp.firstChild);
+                }
+            } else {
+                const fallbackText = stripDelimiters(
+                    mathEl.textContent || '',
+                    isDisplay ? 'display' : 'inline'
+                );
+                replacement.textContent = fallbackText;
+            }
+
             mathEl.replaceWith(replacement);
         });
 


### PR DESCRIPTION
## Summary
- update htmlToXml to hydrate math containers with stored data-pretext markup so embedded tags survive
- keep delimiter stripping fallback that writes plain text with textContent for MathJax-rendered content without stored markup

## Testing
- browser_container.run_playwright_script (manual verification of Visual ↔ Source views with multi-line display math)


------
https://chatgpt.com/codex/tasks/task_e_68d86f030ecc8333bdf336e37203d5f9