### PR TITLE
Add unlimited undo and redo support

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,6 +22,10 @@
                     <button id="save-file" class="btn btn-secondary">Save</button>
                     <input type="file" id="file-input" accept=".ptx,.xml" style="display: none;">
                 </div>
+                <div class="edit-controls">
+                    <button id="undo-action" class="btn btn-secondary" title="Undo (Ctrl+Z)">Undo</button>
+                    <button id="redo-action" class="btn btn-secondary" title="Redo (Ctrl+Y or Ctrl+Shift+Z)">Redo</button>
+                </div>
                 <div class="view-controls">
                     <button id="visual-view" class="btn btn-view active">Visual</button>
                     <button id="source-view" class="btn btn-view">Source</button>

--- a/script.js
+++ b/script.js
@@ -15,7 +15,13 @@ class PreTeXtCanvas {
         };
         this.activeResizer = null;
         this.layoutControlsInitialized = false;
-        
+        this.undoStack = [];
+        this.redoStack = [];
+        this.lastSnapshot = null;
+        this.isApplyingHistory = false;
+        this.historyDebounceTimer = null;
+        this.historyDebounceDelay = 400;
+
         this.init();
     }
 
@@ -30,6 +36,8 @@ class PreTeXtCanvas {
         if (window.MathJax && window.MathJax.typesetPromise) {
             this.renderMath();
         }
+
+        this.recordHistorySnapshot(true);
     }
 
     setupEventListeners() {
@@ -43,6 +51,10 @@ class PreTeXtCanvas {
         document.getElementById('open-file').addEventListener('click', () => this.openFile());
         document.getElementById('save-file').addEventListener('click', () => this.saveFile());
         document.getElementById('file-input').addEventListener('change', (e) => this.handleFileLoad(e));
+
+        // Edit controls
+        document.getElementById('undo-action').addEventListener('click', () => this.undo());
+        document.getElementById('redo-action').addEventListener('click', () => this.redo());
 
         // Panel switching
         document.querySelectorAll('.tab-btn').forEach(btn => {
@@ -347,6 +359,7 @@ class PreTeXtCanvas {
         }
 
         this.markDocumentModified();
+        this.recordHistorySnapshot(true);
         this.generateOutline();
         this.validateDocument();
     }
@@ -460,18 +473,28 @@ class PreTeXtCanvas {
     }
 
     onVisualEdit() {
+        if (this.isApplyingHistory) {
+            return;
+        }
+
         this.markDocumentModified();
         this.syncToSource();
         this.generateOutline();
         this.validateDocument();
         this.renderMath();
+        this.scheduleHistorySnapshot();
     }
 
     onSourceEdit() {
+        if (this.isApplyingHistory) {
+            return;
+        }
+
         this.markDocumentModified();
         this.syncToVisual();
         this.generateOutline();
         this.validateDocument();
+        this.scheduleHistorySnapshot();
     }
 
     syncToSource() {
@@ -816,6 +839,7 @@ class PreTeXtCanvas {
         this.generateOutline();
         this.validateDocument();
         this.updateStatus('New document created');
+        this.recordHistorySnapshot(true);
     }
 
     openFile() {
@@ -840,6 +864,7 @@ class PreTeXtCanvas {
             this.validateDocument();
             this.renderMath();
             this.updateStatus(`Loaded: ${file.name}`);
+            this.recordHistorySnapshot(true);
         };
         reader.readAsText(file);
         
@@ -859,9 +884,15 @@ class PreTeXtCanvas {
         a.click();
         document.body.removeChild(a);
         URL.revokeObjectURL(url);
-        
+
         this.isDocumentModified = false;
         this.updateStatus('Document saved');
+
+        if (this.undoStack.length > 0) {
+            const topSnapshot = this.undoStack[this.undoStack.length - 1];
+            topSnapshot.isDocumentModified = false;
+            this.lastSnapshot = topSnapshot;
+        }
     }
 
     setupDragAndDrop() {
@@ -892,7 +923,8 @@ class PreTeXtCanvas {
 
     handleKeyboardShortcuts(event) {
         if (event.ctrlKey || event.metaKey) {
-            switch (event.key) {
+            const key = event.key.toLowerCase();
+            switch (key) {
                 case 'n':
                     event.preventDefault();
                     this.newDocument();
@@ -916,6 +948,18 @@ class PreTeXtCanvas {
                 case '3':
                     event.preventDefault();
                     this.switchView('split');
+                    break;
+                case 'z':
+                    event.preventDefault();
+                    if (event.shiftKey) {
+                        this.redo();
+                    } else {
+                        this.undo();
+                    }
+                    break;
+                case 'y':
+                    event.preventDefault();
+                    this.redo();
                     break;
             }
         }
@@ -978,6 +1022,126 @@ class PreTeXtCanvas {
         }
 
         cursorPositionEl.textContent = 'Line –, Column –';
+    }
+
+    createSnapshot() {
+        const sourceContent = document.getElementById('source-content');
+        const visualContent = document.getElementById('visual-content');
+
+        return {
+            source: sourceContent ? sourceContent.value : '',
+            visual: visualContent ? visualContent.innerHTML : '',
+            isDocumentModified: this.isDocumentModified
+        };
+    }
+
+    snapshotsEqual(a, b) {
+        if (!a || !b) {
+            return false;
+        }
+        return a.source === b.source && a.visual === b.visual;
+    }
+
+    recordHistorySnapshot(force = false) {
+        if (this.isApplyingHistory) {
+            return;
+        }
+
+        if (this.historyDebounceTimer) {
+            clearTimeout(this.historyDebounceTimer);
+            this.historyDebounceTimer = null;
+        }
+
+        const snapshot = this.createSnapshot();
+
+        if (!this.undoStack.length) {
+            this.undoStack.push(snapshot);
+            this.lastSnapshot = snapshot;
+            this.redoStack = [];
+            return;
+        }
+
+        if (!force && this.lastSnapshot && this.snapshotsEqual(snapshot, this.lastSnapshot)) {
+            return;
+        }
+
+        this.undoStack.push(snapshot);
+        this.lastSnapshot = snapshot;
+        this.redoStack = [];
+    }
+
+    scheduleHistorySnapshot() {
+        if (this.isApplyingHistory) {
+            return;
+        }
+
+        if (this.historyDebounceTimer) {
+            clearTimeout(this.historyDebounceTimer);
+        }
+
+        this.historyDebounceTimer = setTimeout(() => {
+            this.recordHistorySnapshot();
+            this.historyDebounceTimer = null;
+        }, this.historyDebounceDelay);
+    }
+
+    applySnapshot(snapshot) {
+        if (!snapshot) {
+            return;
+        }
+
+        const sourceContent = document.getElementById('source-content');
+        const visualContent = document.getElementById('visual-content');
+
+        if (this.historyDebounceTimer) {
+            clearTimeout(this.historyDebounceTimer);
+            this.historyDebounceTimer = null;
+        }
+
+        this.isApplyingHistory = true;
+
+        if (sourceContent) {
+            sourceContent.value = snapshot.source;
+        }
+
+        if (visualContent) {
+            visualContent.innerHTML = snapshot.visual;
+        }
+
+        this.isDocumentModified = snapshot.isDocumentModified;
+        this.lastSnapshot = snapshot;
+
+        this.generateOutline();
+        this.validateDocument();
+        this.renderMath();
+
+        this.isApplyingHistory = false;
+    }
+
+    undo() {
+        if (this.undoStack.length <= 1) {
+            this.updateStatus('Nothing to undo');
+            return;
+        }
+
+        const currentSnapshot = this.undoStack.pop();
+        this.redoStack.push(currentSnapshot);
+
+        const previousSnapshot = this.undoStack[this.undoStack.length - 1];
+        this.applySnapshot(previousSnapshot);
+        this.updateStatus('Undo');
+    }
+
+    redo() {
+        if (this.redoStack.length === 0) {
+            this.updateStatus('Nothing to redo');
+            return;
+        }
+
+        const snapshot = this.redoStack.pop();
+        this.undoStack.push(snapshot);
+        this.applySnapshot(snapshot);
+        this.updateStatus('Redo');
     }
 
     markDocumentModified() {

--- a/styles.css
+++ b/styles.css
@@ -49,9 +49,12 @@ body {
     font-weight: 600;
 }
 
-.file-controls, .view-controls {
+.file-controls, .edit-controls, .view-controls {
     display: flex;
     gap: 8px;
+}
+.edit-controls {
+    flex-wrap: wrap;
 }
 .view-controls {
     margin-left: auto;


### PR DESCRIPTION
## Summary
- add toolbar buttons for undo and redo alongside keyboard shortcut support
- implement unlimited history tracking with undo/redo stacks and debounced snapshots in the editor logic
- record snapshots for document operations and reset saved-state flags to keep history consistent

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68d88a7cb2f483339f469e14b274bb24