### PR TITLE
Preserve xml:id attributes during HTML to XML conversion

### DIFF
--- a/script.js
+++ b/script.js
@@ -992,6 +992,9 @@ class PreTeXtCanvas {
         container.querySelectorAll('h2').forEach((heading) => {
             const titleEl = document.createElement('title');
             titleEl.innerHTML = heading.innerHTML;
+            if (heading.dataset && heading.dataset.ptxXmlId) {
+                titleEl.setAttribute('xml:id', heading.dataset.ptxXmlId);
+            }
             heading.replaceWith(titleEl);
         });
 
@@ -1013,6 +1016,10 @@ class PreTeXtCanvas {
             const isDisplay = mathEl.classList.contains('math-display');
             const storedPretext = mathEl.dataset.pretext;
             const replacement = document.createElement(isDisplay ? 'md' : 'me');
+
+            if (mathEl.dataset && mathEl.dataset.ptxXmlId) {
+                replacement.setAttribute('xml:id', mathEl.dataset.ptxXmlId);
+            }
 
             if (storedPretext && storedPretext.trim()) {
                 const temp = document.createElement('div');


### PR DESCRIPTION
## Summary
- carry data-ptx-xml-id values from visual headings back to xml:id on generated <title> elements
- ensure math expression/display wrappers propagate data-ptx-xml-id to xml:id when converting to XML
- continue stripping temporary data attributes after conversion

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d8ae58b15c8333a7c854048cde0fe5