### PR TITLE
Add template chooser for new documents

### DIFF
--- a/index.html
+++ b/index.html
@@ -142,6 +142,32 @@
         </footer>
     </div>
 
+    <!-- Template chooser modal -->
+    <div id="template-modal" class="template-modal" aria-hidden="true" role="dialog" aria-modal="true" aria-labelledby="template-modal-title">
+        <div class="template-modal__backdrop" data-template-modal-dismiss></div>
+        <div class="template-modal__dialog">
+            <header class="template-modal__header">
+                <h2 id="template-modal-title" class="template-modal__title">Create a new document</h2>
+                <p class="template-modal__subtitle">Select a starting template to load into the visual and source editors.</p>
+                <button type="button" class="template-modal__close" data-template-modal-dismiss aria-label="Close template chooser">×</button>
+            </header>
+            <div class="template-modal__body">
+                <div id="template-option-list" class="template-modal__list" role="listbox" aria-labelledby="template-modal-title">
+                    <!-- Template cards rendered dynamically -->
+                </div>
+                <div class="template-modal__preview" id="template-preview" aria-live="polite">
+                    <h3 id="template-preview-title" class="template-preview__title">Select a template</h3>
+                    <p id="template-preview-description" class="template-preview__description">Template details and a snippet preview will appear here.</p>
+                    <pre id="template-preview-code" class="template-preview__code"><code></code></pre>
+                </div>
+            </div>
+            <footer class="template-modal__footer">
+                <button type="button" class="btn btn-secondary" id="template-cancel">Cancel</button>
+                <button type="button" class="btn btn-primary" id="template-apply" disabled>Use template</button>
+            </footer>
+        </div>
+    </div>
+
     <!-- MathJax Configuration -->
     <script>
         window.MathJax = {
@@ -158,6 +184,7 @@
         };
     </script>
 
+    <script src="templates.js"></script>
     <script src="script.js"></script>
 </body>
 </html>

--- a/styles.css
+++ b/styles.css
@@ -12,6 +12,10 @@ body {
     overflow: hidden;
 }
 
+body.modal-open {
+    overflow: hidden;
+}
+
 :root {
     --left-sidebar-width: 280px;
     --right-sidebar-width: 280px;
@@ -772,9 +776,208 @@ body.resizing-sidebar * {
         background: #505050;
     }
 
-    .sidebar-resizer:hover::after,
-    body.resizing-sidebar .sidebar-resizer::after {
-        background: #66b0ff;
+.sidebar-resizer:hover::after,
+body.resizing-sidebar .sidebar-resizer::after {
+    background: #66b0ff;
+}
+}
+
+/* Template modal */
+.template-modal {
+    position: fixed;
+    inset: 0;
+    display: none;
+    align-items: center;
+    justify-content: center;
+    z-index: 2000;
+}
+
+.template-modal[aria-hidden="false"] {
+    display: flex;
+}
+
+.template-modal__backdrop {
+    position: absolute;
+    inset: 0;
+    background: rgba(20, 24, 31, 0.45);
+}
+
+.template-modal__dialog {
+    position: relative;
+    background: #ffffff;
+    border-radius: 10px;
+    box-shadow: 0 18px 56px rgba(15, 23, 42, 0.25);
+    width: min(960px, 94vw);
+    max-height: 90vh;
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+    border: 1px solid rgba(15, 23, 42, 0.08);
+}
+
+.template-modal__header {
+    padding: 24px 28px 12px;
+    border-bottom: 1px solid #eef1f6;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.template-modal__title {
+    font-size: 20px;
+    font-weight: 600;
+    color: #1f2937;
+}
+
+.template-modal__subtitle {
+    font-size: 14px;
+    color: #4b5563;
+}
+
+.template-modal__close {
+    position: absolute;
+    top: 18px;
+    right: 18px;
+    border: none;
+    background: transparent;
+    font-size: 20px;
+    color: #6b7280;
+    cursor: pointer;
+    padding: 4px;
+    border-radius: 4px;
+    line-height: 1;
+}
+
+.template-modal__close:hover,
+.template-modal__close:focus-visible {
+    background: rgba(107, 114, 128, 0.12);
+    color: #111827;
+    outline: none;
+}
+
+.template-modal__body {
+    display: flex;
+    gap: 20px;
+    padding: 20px 28px;
+    flex: 1;
+    overflow: hidden;
+}
+
+.template-modal__list {
+    flex: 0 0 320px;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    overflow-y: auto;
+    padding-right: 4px;
+}
+
+.template-card {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 6px;
+    padding: 12px 14px;
+    border-radius: 8px;
+    border: 1px solid #d9e2f2;
+    background: #ffffff;
+    cursor: pointer;
+    transition: border-color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
+    text-align: left;
+    color: inherit;
+}
+
+.template-card:focus-visible {
+    outline: 2px solid #2563eb;
+    outline-offset: 2px;
+}
+
+.template-card:hover {
+    border-color: #9bb5e9;
+    box-shadow: 0 8px 20px rgba(37, 99, 235, 0.08);
+}
+
+.template-card.active {
+    border-color: #2563eb;
+    box-shadow: 0 10px 24px rgba(37, 99, 235, 0.12);
+}
+
+.template-card__title {
+    font-size: 16px;
+    font-weight: 600;
+    color: #1f2937;
+}
+
+.template-card__description {
+    font-size: 13px;
+    color: #4b5563;
+}
+
+.template-modal__preview {
+    flex: 1 1 auto;
+    border: 1px solid #e5e7eb;
+    border-radius: 10px;
+    background: linear-gradient(180deg, #f8fafc 0%, #ffffff 40%);
+    padding: 18px 20px;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    overflow: hidden;
+}
+
+.template-preview__title {
+    font-size: 18px;
+    font-weight: 600;
+    color: #1f2937;
+}
+
+.template-preview__description {
+    font-size: 13px;
+    color: #374151;
+}
+
+.template-preview__code {
+    flex: 1;
+    background: #0f172a;
+    color: #f9fafb;
+    border-radius: 8px;
+    padding: 16px;
+    overflow: auto;
+    font-family: 'Fira Code', 'Source Code Pro', Consolas, 'Courier New', monospace;
+    font-size: 12px;
+    line-height: 1.5;
+}
+
+.template-preview__code code {
+    display: block;
+    white-space: pre;
+}
+
+.template-modal__footer {
+    border-top: 1px solid #eef1f6;
+    padding: 16px 28px;
+    display: flex;
+    justify-content: flex-end;
+    gap: 12px;
+    background: #f9fafb;
+}
+
+.visual-xml-fallback {
+    background: #0f172a;
+    color: #f9fafb;
+    padding: 16px;
+    border-radius: 8px;
+    white-space: pre-wrap;
+}
+
+@media (max-width: 900px) {
+    .template-modal__body {
+        flex-direction: column;
+    }
+
+    .template-modal__list {
+        flex: 0 0 auto;
+        max-height: 220px;
     }
 }
 

--- a/templates.js
+++ b/templates.js
@@ -1,0 +1,162 @@
+(function (global) {
+    const templates = [
+        {
+            id: 'starter-book',
+            label: 'Book: Course Starter',
+            description: 'Structured for multi-chapter projects with docinfo macros and a ready-made introduction.',
+            preview: `<book xml:id="course-book">
+    <title>Course Title</title>
+    <chapter xml:id="ch-introduction">…</chapter>
+</book>`,
+            skeleton: `<?xml version="1.0" encoding="UTF-8"?>
+<pretext xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en-US">
+    <docinfo>
+        <macros>
+        \\newcommand{\\R}{\\mathbb R}
+        </macros>
+    </docinfo>
+
+    <book xml:id="course-book">
+        <title>Course Title</title>
+
+        <chapter xml:id="ch-introduction">
+            <title>Introduction</title>
+
+            <section xml:id="sec-overview">
+                <title>Overview</title>
+
+                <p>
+                    Describe the goals and structure of your course or text here.
+                </p>
+
+            </section>
+
+            <section xml:id="sec-first-steps">
+                <title>First Steps</title>
+
+                <p>
+                    Outline the first topic students should explore.
+                </p>
+
+            </section>
+        </chapter>
+    </book>
+</pretext>`
+        },
+        {
+            id: 'concise-article',
+            label: 'Article: Concise Overview',
+            description: 'A streamlined article with two sections for quick notes or briefs.',
+            preview: `<article xml:id="overview-article">
+    <section xml:id="sec-introduction">…</section>
+    <section xml:id="sec-summary">…</section>
+</article>`,
+            skeleton: `<?xml version="1.0" encoding="UTF-8"?>
+<pretext xmlns:xi="http://www.w3.org/2001/XInclude">
+    <article xml:id="overview-article">
+        <title>Concise Overview</title>
+
+        <section xml:id="sec-introduction">
+            <title>Introduction</title>
+            <p>Use this space to introduce the main topic.</p>
+            <p>Add supporting remarks with <em>emphasis</em> or inline <c>code</c> as needed.</p>
+        </section>
+
+        <section xml:id="sec-summary">
+            <title>Summary</title>
+            <p>Conclude your short article and reference earlier ideas with <xref ref="sec-introduction"/>.</p>
+        </section>
+    </article>
+</pretext>`
+        },
+        {
+            id: 'math-forward-article',
+            label: 'Article: Math Forward',
+            description: 'Includes inline and display mathematics plus theorem-style structures.',
+            preview: `<article xml:id="math-forward">
+    <section xml:id="sec-basic-math">…</section>
+    <theorem xml:id="thm-main">…</theorem>
+</article>`,
+            skeleton: `<?xml version="1.0" encoding="UTF-8"?>
+<pretext xmlns:xi="http://www.w3.org/2001/XInclude">
+    <article xml:id="math-forward">
+        <title>Mathematics Notes</title>
+
+        <section xml:id="sec-basic-math">
+            <title>Foundations</title>
+            <p>Inline math: <m>x^2 + y^2 = z^2</m> and <m>\\frac{1}{2}</m>.</p>
+            <p>Display computation:</p>
+            <me>\\int_0^1 x^2 \, dx = \\frac{1}{3}</me>
+        </section>
+
+        <section xml:id="sec-theorems">
+            <title>Key Results</title>
+            <definition xml:id="def-limit">
+                <title>Limit</title>
+                <statement>
+                    <p>The limit of <m>f(x)</m> as <m>x</m> approaches <m>a</m> is <m>L</m> if:</p>
+                    <me>\\lim_{x \\to a} f(x) = L</me>
+                </statement>
+            </definition>
+            <theorem xml:id="thm-fundamental">
+                <title>Fundamental Theorem of Calculus</title>
+                <statement>
+                    <p>If <m>f</m> is continuous on <m>[a,b]</m>, then:</p>
+                    <me>\\int_a^b f(x) \, dx = F(b) - F(a)</me>
+                    <p>where <m>F'(x) = f(x)</m>.</p>
+                </statement>
+                <proof>
+                    <p>Sketch the proof using supporting text or references.</p>
+                </proof>
+            </theorem>
+        </section>
+    </article>
+</pretext>`
+        },
+        {
+            id: 'activity-handbook',
+            label: 'Activity & Exercises',
+            description: 'Starter layout for worksheets that combine examples with student tasks.',
+            preview: `<article xml:id="activity-handbook">
+    <example xml:id="ex-sample">…</example>
+    <exercise xml:id="exr-practice">…</exercise>
+</article>`,
+            skeleton: `<?xml version="1.0" encoding="UTF-8"?>
+<pretext xmlns:xi="http://www.w3.org/2001/XInclude">
+    <article xml:id="activity-handbook">
+        <title>Activity Handbook</title>
+
+        <section xml:id="sec-guided-example">
+            <title>Guided Example</title>
+            <example xml:id="ex-guided">
+                <title>Working Example</title>
+                <statement>
+                    <p>Present a motivating problem or scenario.</p>
+                </statement>
+                <solution>
+                    <p>Demonstrate the steps students should follow.</p>
+                </solution>
+            </example>
+        </section>
+
+        <section xml:id="sec-practice">
+            <title>Practice</title>
+            <exercise xml:id="exr-practice">
+                <statement>
+                    <p>Provide a related task for learners to attempt independently.</p>
+                </statement>
+                <hint>
+                    <p>Offer a gentle hint or remove this element if not needed.</p>
+                </hint>
+                <solution>
+                    <p>Summarize the expected reasoning or final answer.</p>
+                </solution>
+            </exercise>
+        </section>
+    </article>
+</pretext>`
+        }
+    ];
+
+    global.PreTeXtTemplates = templates;
+})(window);


### PR DESCRIPTION
## Summary
- add a template chooser modal to the New workflow with previews, descriptions, and controls
- load document skeletons from a dedicated templates.js module and persist the last selection
- update editor logic and styling so the chosen skeleton initializes both editors and resets history/validation

## Testing
- Manual: python3 -m http.server 8000


------
https://chatgpt.com/codex/tasks/task_e_68d8cab5b83c83338a8cc565a7270dbd